### PR TITLE
Fix scenario and step counting for loops

### DIFF
--- a/radish/extensions/endreport_writer.py
+++ b/radish/extensions/endreport_writer.py
@@ -13,6 +13,7 @@ from radish.hookregistry import after
 from radish.step import Step
 from radish.utils import console_write as write
 from radish.scenariooutline import ScenarioOutline
+from radish.scenarioloop import ScenarioLoop
 
 
 @after.all  # pylint: disable=no-member
@@ -37,6 +38,8 @@ def console_write_after_all(features, marker):
 
         for scenario in feature.all_scenarios:
             if isinstance(scenario, ScenarioOutline):  # skip ScenarioOutlines
+                continue
+            if isinstance(scenario, ScenarioLoop):  # skip ScenarioLoop
                 continue
 
             stats["scenarios"]["amount"] += 1


### PR DESCRIPTION
Skip ScenarioLoop for the total scenario and step counting, since a ScenarioLoop not really get executed. 

```
Scenario Loop: Initialize Module
    I run Module.Init( )
    I expect event Module.ModuleStateChanged( ModuleState = 3 )
    I expect event Module.ModuleStateChanged( ModuleState = 4, OldModuleState = 3 )

Iterations: 2
    | 0     |
    | 1     |
``` 

Without the fix it counts this as 

```
1 features (1 passed)
7 scenarios (6 passed)
22 steps (19 passed)
```

Which is 1 scenario and 3 steps too much.

With the fix:

```
1 features (1 passed)
6 scenarios (6 passed)
19 steps (19 passed)
 ```
