### PR TITLE
Add framework to test radish step implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Vendor `parse` package until [parse (#38)](https://github.com/r1chardj0n3s/parse/pull/38) is merged
+- Implement `radish-test` to test step patterns
 
 ### Fixed
 - Lazy evaluate matched step arguments. Refs #31

--- a/radish/main.py
+++ b/radish/main.py
@@ -136,7 +136,7 @@ Options:
     --expand                                    expand the feature file (all preconditions)
     {1}
 
-(C) Copyright 2017 by Timo Furrer <tuxtimo@gmail.com>
+(C) Copyright by Timo Furrer <tuxtimo@gmail.com>
     """
 
     # load extensions

--- a/radish/testing/__main__.py
+++ b/radish/testing/__main__.py
@@ -8,22 +8,24 @@ radish step implementations
 import sys
 
 from docopt import docopt
-from colorful import colorful
 
 from radish import __VERSION__
-from radish.testing.matches import test_step_matches
+from radish.testing.matches import test_step_matches_configs
 
 
 def main():
     """
 Usage:
-    radish-test matches [-b=<basedir> | --basedir=<basedir>]
+    radish-test matches <match-configs>...
+        [-b=<basedir> | --basedir=<basedir>]
     radish-test (-h | --help)
     radish-test (-v | --version)
 
+Arguments:
+    match-configs                       configuration files of step matcher tests
+
 Commands:
-    matches                             test if the step implemention matchers actually match the expected sentences
-                                        The match configuration can be found in radish-matches.yml
+    matches                             test if the step implementions actually match the expected sentences
 
 Options:
     -h --help                           show this screen
@@ -37,18 +39,7 @@ Options:
 
 
     if arguments['matches']:
-        failed, passed = test_step_matches('tests/radish-matches.yml', arguments['--basedir'])
-        report = colorful.bold_white('{0} sentences ('.format(failed + passed))
-        if passed > 0:
-            report += colorful.bold_green('{0} passed'.format(passed))
-
-        if passed > 0 and failed > 0:
-            report += colorful.bold_white(', ')
-
-        if failed > 0:
-            report += colorful.bold_red('{0} failed'.format(failed))
-        report += colorful.bold_white(')')
-        print('\n' + report)
+        return test_step_matches_configs(arguments['<match-configs>'], arguments['--basedir'])
 
 
 if __name__ == "__main__":

--- a/radish/testing/__main__.py
+++ b/radish/testing/__main__.py
@@ -19,6 +19,7 @@ Usage:
     radish-test matches <match-configs>...
         [-b=<basedir> | --basedir=<basedir>]
         [--cover-min-percentage=<cover-min-percentage>]
+        [--cover-show-missing]
     radish-test (-h | --help)
     radish-test (-v | --version)
 
@@ -33,6 +34,7 @@ Options:
     -v --version                                   show version
     -b=<basedir> --basedir=<basedir>               set base dir from where the step.py and terrain.py will be loaded [default: $PWD/radish]
     --cover-min-percentage=<cover-min-percentage>  minimum percentage of step coverage for tests to pass
+    --cover-show-missing                           show steps which are not tested
 
 (C) Copyright by Timo Furrer <tuxtimo@gmail.com>
     """
@@ -41,7 +43,8 @@ Options:
 
 
     if arguments['matches']:
-        return test_step_matches_configs(arguments['<match-configs>'], arguments['--basedir'], arguments['--cover-min-percentage'])
+        return test_step_matches_configs(arguments['<match-configs>'],
+             arguments['--basedir'], arguments['--cover-min-percentage'], arguments['--cover-show-missing'])
 
 
 if __name__ == "__main__":

--- a/radish/testing/__main__.py
+++ b/radish/testing/__main__.py
@@ -18,19 +18,21 @@ def main():
 Usage:
     radish-test matches <match-configs>...
         [-b=<basedir> | --basedir=<basedir>]
+        [--cover-min-percentage=<cover-min-percentage>]
     radish-test (-h | --help)
     radish-test (-v | --version)
 
 Arguments:
-    match-configs                       configuration files of step matcher tests
+    match-configs                                  configuration files of step matcher tests
 
 Commands:
-    matches                             test if the step implementions actually match the expected sentences
+    matches                                        test if the step implementions actually match the expected sentences
 
 Options:
-    -h --help                           show this screen
-    -v --version                        show version
-    -b=<basedir> --basedir=<basedir>    set base dir from where the step.py and terrain.py will be loaded [default: $PWD/radish]
+    -h --help                                      show this screen
+    -v --version                                   show version
+    -b=<basedir> --basedir=<basedir>               set base dir from where the step.py and terrain.py will be loaded [default: $PWD/radish]
+    --cover-min-percentage=<cover-min-percentage>  minimum percentage of step coverage for tests to pass
 
 (C) Copyright by Timo Furrer <tuxtimo@gmail.com>
     """
@@ -39,7 +41,7 @@ Options:
 
 
     if arguments['matches']:
-        return test_step_matches_configs(arguments['<match-configs>'], arguments['--basedir'])
+        return test_step_matches_configs(arguments['<match-configs>'], arguments['--basedir'], arguments['--cover-min-percentage'])
 
 
 if __name__ == "__main__":

--- a/radish/testing/__main__.py
+++ b/radish/testing/__main__.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+"""
+This module provides a script to test the
+radish step implementations
+"""
+
+import sys
+
+from docopt import docopt
+from colorful import colorful
+
+from radish import __VERSION__
+from radish.testing.matches import test_step_matches
+
+
+def main():
+    """
+Usage:
+    radish-test matches [-b=<basedir> | --basedir=<basedir>]
+    radish-test (-h | --help)
+    radish-test (-v | --version)
+
+Commands:
+    matches                             test if the step implemention matchers actually match the expected sentences
+                                        The match configuration can be found in radish-matches.yml
+
+Options:
+    -h --help                           show this screen
+    -v --version                        show version
+    -b=<basedir> --basedir=<basedir>    set base dir from where the step.py and terrain.py will be loaded [default: $PWD/radish]
+
+(C) Copyright by Timo Furrer <tuxtimo@gmail.com>
+    """
+
+    arguments = docopt("radish-test {0}\n{1}".format(__VERSION__, main.__doc__), version=__VERSION__)
+
+
+    if arguments['matches']:
+        failed, passed = test_step_matches('tests/radish-matches.yml', arguments['--basedir'])
+        report = colorful.bold_white('{0} sentences ('.format(failed + passed))
+        if passed > 0:
+            report += colorful.bold_green('{0} passed'.format(passed))
+
+        if passed > 0 and failed > 0:
+            report += colorful.bold_white(', ')
+
+        if failed > 0:
+            report += colorful.bold_red('{0} failed'.format(failed))
+        report += colorful.bold_white(')')
+        print('\n' + report)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/radish/testing/matches.py
+++ b/radish/testing/matches.py
@@ -164,7 +164,7 @@ def check_step_arguments(expected_arguments, arguments):
 
         if arguments[arg_name] != value:
             errors.append('Expected argument "{0}" with value "{1}" does not match value "{2}"'.format(
-                arg_name, arg_value, arguments[arg_name]))
+                arg_name, value, arguments[arg_name]))
     return errors
 
 

--- a/radish/testing/matches.py
+++ b/radish/testing/matches.py
@@ -23,6 +23,11 @@ def test_step_matches_configs(match_config_files, basedir, cover_min_percentage=
     Test if the given match config files matches the actual
     matched step implementations.
     """
+    if cover_min_percentage is not None and float(cover_min_percentage) > 100:
+        sys.stderr.write(colorful.magenta('You are a little cocky to think you can reach a minimum coverage of {0:.2f}%\n'.format(
+            float(cover_min_percentage))))
+        return 3
+
     # load user's custom python files
     load_modules(basedir)
     steps = StepRegistry().steps

--- a/radish/testing/matches.py
+++ b/radish/testing/matches.py
@@ -41,12 +41,15 @@ def test_step_matches_configs(match_config_files, basedir, cover_min_percentage=
         with codecs.open(match_config_file, "r", "utf-8") as f:
             match_config = yaml.safe_load(f)
 
-        print(colorful.brown('Testing sentences from {0}:'.format(colorful.bold_brown(match_config_file))))
-        failed_sentences, passed_senteces = test_step_matches(match_config, steps)
-        failed += failed_sentences
-        passed += passed_senteces
+        if not match_config:
+            print(colorful.magenta('No sentences found in {0} to test against'.format(match_config_file)))
+        else:
+            print(colorful.brown('Testing sentences from {0}:'.format(colorful.bold_brown(match_config_file))))
+            failed_sentences, passed_senteces = test_step_matches(match_config, steps)
+            failed += failed_sentences
+            passed += passed_senteces
 
-        covered_steps = covered_steps.union(x['should_match'] for x in match_config)
+            covered_steps = covered_steps.union(x['should_match'] for x in match_config)
 
         # newline
         sys.stdout.write('\n')

--- a/radish/testing/matches.py
+++ b/radish/testing/matches.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+"""
+This module provides functionaliy to test
+if some sentences are matched with the expected
+step implementations.
+"""
+
+import sys
+import codecs
+
+import yaml
+from colorful import colorful
+
+from radish.loader import load_modules
+from radish.matcher import match_step
+from radish.stepregistry import StepRegistry
+from radish.utils import get_func_arg_names
+
+
+def test_step_matches(match_config_file, basedir):
+    """
+    Test if the given match config matches the actual
+    matched step implementations.
+    """
+    # load the given match config file
+    with codecs.open(match_config_file, "r", "utf-8") as f:
+        match_config = yaml.safe_load(f)
+
+    # load user's custom python files
+    load_modules(basedir)
+
+    steps = StepRegistry().steps
+
+    failed = 0
+    passed = 0
+
+    for item in match_config:
+        if 'sentence' not in item or 'should_match' not in item:
+            raise ValueError('You have provide a sentence and the function name which should be matched (should_match)')
+
+        sentence = item['sentence']
+        expected_step = item['should_match']
+
+        sys.stdout.write('{0} STEP "{1}" SHOULD MATCH {2}    '.format(
+            colorful.brown('>>'), colorful.cyan(sentence), colorful.cyan(expected_step)))
+
+        result = match_step(item['sentence'], steps)
+        if not result:
+            output_failure(['Expected sentence didn\'t match any step implemention'])
+            failed += 1
+            continue
+
+        if expected_step != result.func.__name__:
+            output_failure(['Expected sentence matched {0} instead of {1}'.format(result.func.__name__, expected_step)])
+            failed += 1
+            continue
+
+
+        expected_arguments = item.get('with-arguments')
+
+        if expected_arguments:
+            arguments = merge_step_args(result)
+            expected_arguments = {k: v for expected_arguments in expected_arguments for k, v in expected_arguments.items()}
+            argument_errors = check_step_arguments(expected_arguments, arguments)
+            if argument_errors:
+                output_failure(argument_errors)
+                failed += 1
+                continue
+
+        # check if arguments match
+        print(colorful.bold_green('✔'))
+        passed += 1
+
+    return failed, passed
+
+
+def output_failure(errors):
+    """
+    Write the given errors to stdout.
+    """
+    print(colorful.bold_red('✘'))
+    for error in errors:
+        print(colorful.red('  - {0}'.format(error)))
+
+
+
+def check_step_arguments(expected_arguments, arguments):
+    """
+    Check if the given expected arguments
+    match the actual arguments
+    """
+    errors = []
+    for arg_name, arg_value in expected_arguments.items():
+        if arg_name not in arguments:
+            errors.append('Expected argument "{0}" is not in matched arguments {1}'.format(
+                arg_name, list(arguments.keys())))
+            continue
+
+        if arguments[arg_name] != arg_value:
+            errors.append('Expected argument "{0}" with value "{1}" does not match value "{2}"'.format(
+                arg_name, arg_value, arguments[arg_name]))
+    return errors
+
+
+def merge_step_args(step_func):
+    """
+    Merges the arguments and keyword arguments
+    of the given step function.
+    """
+    #: Holds the merged arguments as a dict with the corresponding matched values
+    step_arg_names = get_func_arg_names(step_func.func)[1:]
+    arguments = dict(zip(step_arg_names, step_func.args))
+    arguments.update(step_func.kwargs)
+    return arguments

--- a/radish/testing/matches.py
+++ b/radish/testing/matches.py
@@ -18,7 +18,7 @@ from radish.stepregistry import StepRegistry
 from radish.utils import get_func_arg_names, get_func_location
 
 
-def test_step_matches_configs(match_config_files, basedir, cover_min_percentage=None):
+def test_step_matches_configs(match_config_files, basedir, cover_min_percentage=None, cover_show_missing=False):
     """
     Test if the given match config files matches the actual
     matched step implementations.
@@ -89,7 +89,18 @@ def test_step_matches_configs(match_config_files, basedir, cover_min_percentage=
                 ret = 2
             # if tests have passed and coverage is too low we fail with exit code 2
         coverage_report += colorful.bold_white(')')
+
     print(coverage_report)
+
+    if cover_show_missing:
+        missing_steps = get_missing_steps(steps, covered_steps)
+        if missing_steps:
+            missing_step_report = colorful.bold_brown('Missing steps:\n')
+            for step in missing_steps:
+                missing_step_report += '- {0} at '.format(
+                    colorful.cyan(step[0]))
+                missing_step_report += colorful.cyan(step[1]) + '\n'
+            sys.stdout.write(missing_step_report)
 
     return ret
 
@@ -198,3 +209,15 @@ def merge_step_args(step_func):
     arguments = dict(zip(step_arg_names, args))
     arguments.update(kwargs)
     return arguments
+
+
+def get_missing_steps(steps, covered_steps):
+    """
+    Get all steps within ``steps`` which are not
+    covered by ``covered_steps``.
+    """
+    missing_steps = []
+    for step_func in steps.values():
+        if step_func.__name__ not in covered_steps:
+            missing_steps.append((step_func.__name__, get_func_location(step_func)))
+    return missing_steps

--- a/radish/testing/matches.py
+++ b/radish/testing/matches.py
@@ -127,7 +127,20 @@ def check_step_arguments(expected_arguments, arguments):
                 arg_name, list(arguments.keys())))
             continue
 
-        if arguments[arg_name] != arg_value:
+        # check if argument value is a dict, if yes we'll do thorough comparison
+        if isinstance(arg_value, dict):
+            _type = arg_value['type']
+            value = arg_value['value']
+        else:
+            _type = type(arg_value).__name__
+            value = arg_value
+
+        if type(arguments[arg_name]).__name__ != _type:
+            errors.append('Expected argument "{0}" is of type "{1}" instead "{2}"'.format(
+                arg_name, type(arguments[arg_name]).__name__, _type))
+            continue
+
+        if arguments[arg_name] != value:
             errors.append('Expected argument "{0}" with value "{1}" does not match value "{2}"'.format(
                 arg_name, arg_value, arguments[arg_name]))
     return errors

--- a/radish/testing/matches.py
+++ b/radish/testing/matches.py
@@ -115,7 +115,6 @@ def output_failure(errors):
         print(colorful.red('  - {0}'.format(error)))
 
 
-
 def check_step_arguments(expected_arguments, arguments):
     """
     Check if the given expected arguments

--- a/radish/testing/matches.py
+++ b/radish/testing/matches.py
@@ -32,6 +32,11 @@ def test_step_matches_configs(match_config_files, basedir, cover_min_percentage=
     load_modules(basedir)
     steps = StepRegistry().steps
 
+    if not steps:
+        sys.stderr.write(colorful.magenta('No step implementations found in {0}, thus doesn\'t make sense to continue'.format(
+            basedir)))
+        return 4
+
     failed = 0
     passed = 0
     covered_steps = set()
@@ -43,6 +48,7 @@ def test_step_matches_configs(match_config_files, basedir, cover_min_percentage=
 
         if not match_config:
             print(colorful.magenta('No sentences found in {0} to test against'.format(match_config_file)))
+            return 5
         else:
             print(colorful.brown('Testing sentences from {0}:'.format(colorful.bold_brown(match_config_file))))
             failed_sentences, passed_senteces = test_step_matches(match_config, steps)

--- a/radish/testing/matches.py
+++ b/radish/testing/matches.py
@@ -18,20 +18,51 @@ from radish.stepregistry import StepRegistry
 from radish.utils import get_func_arg_names
 
 
-def test_step_matches(match_config_file, basedir):
+def test_step_matches_configs(match_config_files, basedir):
+    """
+    Test if the given match config files matches the actual
+    matched step implementations.
+    """
+    # load user's custom python files
+    load_modules(basedir)
+    steps = StepRegistry().steps
+
+    failed = 0
+    passed = 0
+
+    for match_config_file in match_config_files:
+        # load the given match config file
+        with codecs.open(match_config_file, "r", "utf-8") as f:
+            match_config = yaml.safe_load(f)
+
+        print(colorful.brown('Testing sentences from {0}:'.format(colorful.bold_brown(match_config_file))))
+        failed_sentences, passed_senteces = test_step_matches(match_config, steps)
+        failed += failed_sentences
+        passed += passed_senteces
+
+        # newline
+        sys.stdout.write('\n')
+
+    report = colorful.bold_white('{0} sentences ('.format(failed + passed))
+    if passed > 0:
+        report += colorful.bold_green('{0} passed'.format(passed))
+
+    if passed > 0 and failed > 0:
+        report += colorful.bold_white(', ')
+
+    if failed > 0:
+        report += colorful.bold_red('{0} failed'.format(failed))
+    report += colorful.bold_white(')')
+    print(report)
+
+    return 0 if failed == 0 else 1
+
+
+def test_step_matches(match_config, steps):
     """
     Test if the given match config matches the actual
     matched step implementations.
     """
-    # load the given match config file
-    with codecs.open(match_config_file, "r", "utf-8") as f:
-        match_config = yaml.safe_load(f)
-
-    # load user's custom python files
-    load_modules(basedir)
-
-    steps = StepRegistry().steps
-
     failed = 0
     passed = 0
 

--- a/radish/testing/matches.py
+++ b/radish/testing/matches.py
@@ -193,7 +193,8 @@ def merge_step_args(step_func):
     of the given step function.
     """
     #: Holds the merged arguments as a dict with the corresponding matched values
+    args, kwargs = step_func.argument_match.evaluate()
     step_arg_names = get_func_arg_names(step_func.func)[1:]
-    arguments = dict(zip(step_arg_names, step_func.args))
-    arguments.update(step_func.kwargs)
+    arguments = dict(zip(step_arg_names, args))
+    arguments.update(kwargs)
     return arguments

--- a/radish/testing/matches.py
+++ b/radish/testing/matches.py
@@ -104,7 +104,7 @@ def test_step_matches(match_config, steps):
 
     for item in match_config:
         if 'sentence' not in item or 'should_match' not in item:
-            raise ValueError('You have provide a sentence and the function name which should be matched (should_match)')
+            raise ValueError('You have to provide a sentence and the function name which should be matched (should_match)')
 
         sentence = item['sentence']
         expected_step = item['should_match']

--- a/radish/utils.py
+++ b/radish/utils.py
@@ -131,3 +131,10 @@ def get_func_code(func):
         return func.__code__
     else:
         return func.func_code
+
+
+def get_func_arg_names(func):
+    """
+        Get the argument names of the given function.
+    """
+    return get_func_code(func).co_varnames

--- a/radish/utils.py
+++ b/radish/utils.py
@@ -138,3 +138,11 @@ def get_func_arg_names(func):
         Get the argument names of the given function.
     """
     return get_func_code(func).co_varnames
+
+
+def get_func_location(func):
+    """
+        Get the location where the given function is implemented.
+    """
+    func_code = get_func_code(func)
+    return '{0}:{1}'.format(func_code.co_filename, func_code.co_firstlineno)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ipython
 lxml
 parse
 coverage
+PyYAML

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,21 @@ setup(
     bugtrack_url=get_meta("bugtrack_url"),
     packages=find_packages(),
     package_data={"": ["radish/languages/*", "*.md"]},
-    install_requires=["docopt", "pysingleton", "colorful>=0.01.03", "lxml", "ipython", "coverage"],
+    install_requires=[
+        "docopt",
+        "pysingleton",
+        "colorful>=0.01.03",
+        "lxml",
+        "ipython",
+        "coverage",
+        "PyYAML"
+    ],
     include_package_data=True,
-    entry_points={"console_scripts": ["radish = radish.main:main"]},
+    entry_points={
+        "console_scripts": [
+            "radish = radish.main:main",
+            'radish-test = radish.testing.__main__:main',
+        ]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,5 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import sys
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 import sure
 from unittest import TestCase
 from mock import Mock, patch, MagicMock
@@ -12,7 +19,6 @@ def is_python3(minor=0):
     """
         Check if python is in version 3.
     """
-    import sys
     return sys.version_info >= (3, minor)
 
 

--- a/tests/functional.sh
+++ b/tests/functional.sh
@@ -2,9 +2,10 @@
 
 ROOT=$(dirname "$0")
 TESTS_ROOT=functional
-RADISH_BASEDIR=radish
-FEATURES_DIR=features
+
 RADISH_BIN=radish/main.py
+RADISH_TEST_BIN=radish/main.py
+
 BASE_COVERAGE_FILE=$(pwd)/.coverage
 COVERAGE_RC=$(pwd)/.coveragerc
 
@@ -12,15 +13,29 @@ if [ -n "${VIRTUAL_ENV}" ]; then
     # we are running inside a python virtualenv
     VIRTUAL_ENV_BIN=${VIRTUAL_ENV}/bin
     RADISH_BIN=${VIRTUAL_ENV_BIN}/radish
+    RADISH_TEST_BIN=${VIRTUAL_ENV_BIN}/radish-test
 fi
 
-cd "$ROOT/$TESTS_ROOT"
+cd "${ROOT}/${TESTS_ROOT}"
 
 for t in *; do
-    export COVERAGE_FILE=${BASE_COVERAGE_FILE}.$t
-    PYTHONPATH="${t}" coverage run -a --rcfile="${COVERAGE_RC}" --source=radish "${RADISH_BIN}" -b "$t/$RADISH_BASEDIR" "$t/$FEATURES_DIR"
+    export COVERAGE_FILE=${BASE_COVERAGE_FILE}.${t}
+
+    BASE_DIR="${t}/radish"
+    FEATURES_DIR="${t}/features"
+    MATCHES_FILE="${t}/tests/radish-matches.yml"
+
+    if [ -f "${MATCHES_FILE}" ]; then
+        coverage run -a --rcfile="${COVERAGE_RC}" --source=radish "${RADISH_TEST_BIN}" matches -b "${BASE_DIR}" "${MATCHES_FILE}"
+        if [ $? -ne 0 ]; then
+            echo "Functional tests from '${t}' failed to match steps with status $?"
+            exit 1
+        fi
+    fi
+
+    PYTHONPATH="${t}" coverage run -a --rcfile="${COVERAGE_RC}" --source=radish "${RADISH_BIN}" -b "${BASE_DIR}" "${FEATURES_DIR}"
     if [ $? -ne 0 ]; then
-        echo "Functional tests from '$t' failed with status $?"
+        echo "Functional tests from '${t}' failed with status $?"
         exit 1
     fi
 done

--- a/tests/functional.sh
+++ b/tests/functional.sh
@@ -26,7 +26,7 @@ for t in *; do
     MATCHES_FILE="${t}/tests/radish-matches.yml"
 
     if [ -f "${MATCHES_FILE}" ]; then
-        coverage run -a --rcfile="${COVERAGE_RC}" --source=radish "${RADISH_TEST_BIN}" matches -b "${BASE_DIR}" "${MATCHES_FILE}"
+        PYTHONPATH="${t}" coverage run -a --rcfile="${COVERAGE_RC}" --source=radish "${RADISH_TEST_BIN}" matches -b "${BASE_DIR}" "${MATCHES_FILE}"
         if [ $? -ne 0 ]; then
             echo "Functional tests from '${t}' failed to match steps with status $?"
             exit 1

--- a/tests/functional/basic/radish/steps.py
+++ b/tests/functional/basic/radish/steps.py
@@ -8,7 +8,7 @@ def have_number(step, number):
     step.context.numbers.append(number)
 
 @when("I sum them")
-def sum_numbres(step):
+def sum_numbers(step):
     step.context.result = sum(step.context.numbers)
 
 @then("I expect the result to be {result:g}")

--- a/tests/functional/basic/tests/radish-matches.yml
+++ b/tests/functional/basic/tests/radish-matches.yml
@@ -1,7 +1,9 @@
 - sentence: Given I have the number 5
   should_match: have_number
   with-arguments:
-      - number: 5
+      - number:
+            type: float
+            value: 5.0
 
 - sentence: When I sum them
   should_match: sum_numbers
@@ -9,4 +11,4 @@
 - sentence: Then I expect the result to be 8
   should_match: expect_result
   with-arguments:
-      - result: 8
+      - result: 8.0

--- a/tests/functional/basic/tests/radish-matches.yml
+++ b/tests/functional/basic/tests/radish-matches.yml
@@ -1,0 +1,12 @@
+- sentence: Given I have the number 5
+  should_match: have_number
+  with-arguments:
+      - number: 5
+
+- sentence: When I sum them
+  should_match: sum_numbers
+
+- sentence: Then I expect the result to be 8
+  should_match: expect_result
+  with-arguments:
+      - result: 8

--- a/tests/functional/customargexpr/radish/steps.py
+++ b/tests/functional/customargexpr/radish/steps.py
@@ -7,16 +7,16 @@ from example.model import Hero
 
 
 @given('I have the following heros in the database')
-def have_number(step):
+def add_heros_to_db(step):
     world.heros = [Hero(*row) for row in step.table]
 
 
 @when('I query for the hero with name {hero:Hero}')
-def sum_numbres(step, hero):
+def query_hero(step, hero):
     step.context.last_queried_hero = hero
 
 
 @then('I expect it\'s name to be {forename:w} {surname:w}')
-def expect_result(step, forename, surname):
+def expect_hero(step, forename, surname):
     assert step.context.last_queried_hero.forename == forename
     assert step.context.last_queried_hero.surname == surname

--- a/tests/functional/customargexpr/tests/radish-matches.yml
+++ b/tests/functional/customargexpr/tests/radish-matches.yml
@@ -1,14 +1,11 @@
-#- sentence: Given I have the number 5
-  #should_match: have_number
-  #with-arguments:
-      #- number:
-            #type: float
-            #value: 5.0
+- sentence: Given I have the following heros in the database
+  should_match: add_heros_to_db
 
-#- sentence: When I sum them
-  #should_match: sum_numbers
+- sentence: When I query for the hero with name Batman
+  should_match: query_hero
 
-#- sentence: Then I expect the result to be 8
-  #should_match: expect_result
-  #with-arguments:
-      #- result: 8.0
+- sentence: When I query for the hero with name Spiderman
+  should_match: query_hero
+
+- sentence: Then I expect it's name to be Peter Parker
+  should_match: expect_hero

--- a/tests/functional/stepregexpattern/radish/steps.py
+++ b/tests/functional/stepregexpattern/radish/steps.py
@@ -9,7 +9,7 @@ def have_number(step, number):
     step.context.numbers.append(float(number))
 
 @when(re.compile(r"I sum them"))
-def sum_numbres(step):
+def sum_numbers(step):
     step.context.result = sum(step.context.numbers)
 
 @then(re.compile(r"I expect the result to be (\d+)"))

--- a/tests/functional/stepregexpattern/tests/radish-matches.yml
+++ b/tests/functional/stepregexpattern/tests/radish-matches.yml
@@ -1,0 +1,14 @@
+- sentence: Given I have the number 5
+  should_match: have_number
+  with-arguments:
+      - number:
+            type: str
+            value: '5'
+
+- sentence: When I sum them
+  should_match: sum_numbers
+
+- sentence: Then I expect the result to be 8
+  should_match: expect_result
+  with-arguments:
+      - result: '8'

--- a/tests/unit/testing/test_matches.py
+++ b/tests/unit/testing/test_matches.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+
+from tests.base import *
+
+import radish.testing.matches as matches
+
+
+class MatchesTestCase(RadishTestCase):
+    """
+    Unit tests for testing.matches module.
+    """
+    def test_unreasonable_min_coverage(self):
+        """
+        Test unreasonable minimum test coverage
+        """
+        matches.test_step_matches_configs.when.called_with(None, None, 101).should.return_value(3)
+
+    def test_no_steps_found(self):
+        """
+        Test if basedir does not contain any steps to test against
+        """
+        with patch('radish.testing.matches.load_modules'):
+            matches.test_step_matches_configs.when.called_with(None, None).should.return_value(4)
+
+
+    def test_empty_matches_config(self):
+        """
+        Test empty matches config file
+        """
+        # create temporary file
+        fd, tmpfile = tempfile.mkstemp()
+        os.close(fd)
+
+        with patch('radish.testing.matches.load_modules'), patch('radish.testing.matches.StepRegistry.steps') as steps_mock:
+            steps_mock.return_value = [1, 2]
+            matches.test_step_matches_configs.when.called_with([tmpfile], None).should.return_value(5)
+
+        # delete temporary file
+        os.remove(tmpfile)

--- a/tests/unit/testing/test_matches.py
+++ b/tests/unit/testing/test_matches.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 import tempfile
 
 from tests.base import *
@@ -40,3 +41,154 @@ class MatchesTestCase(RadishTestCase):
 
         # delete temporary file
         os.remove(tmpfile)
+
+    def test_step_matches_invalid_match_config(self):
+        """
+        Test match config without a sentence and a should_match attribute
+        """
+        # test config with missing should_match function attribute
+        config = [{
+            'sentence': None
+        }]
+
+        matches.test_step_matches.when.called_with(config, None).should.throw(ValueError,
+            'You have to provide a sentence and the function name which should be matched (should_match)')  # pylint: disable=bad-continuation
+
+
+        # test config with missing sentence attribute
+        config = [{
+            'should_match': None
+        }]
+
+        matches.test_step_matches.when.called_with(config, None).should.throw(ValueError,
+            'You have to provide a sentence and the function name which should be matched (should_match)')  # pylint: disable=bad-continuation
+
+
+        # test empty config
+        config = [{}]
+
+        matches.test_step_matches.when.called_with(config, None).should.throw(ValueError,
+            'You have to provide a sentence and the function name which should be matched (should_match)')  # pylint: disable=bad-continuation
+
+    def test_sentence_no_step_match(self):
+        """
+        Test if sentence does not match any step pattern
+        """
+        steps = {}
+        config = [{
+            'sentence': 'foo', 'should_match': 'bar'
+        }]
+
+        with patch('sys.stdout', new=StringIO()) as out:
+            matches.test_step_matches.when.called_with(config, steps).should.return_value((1, 0))
+            out.seek(0)
+            out.read().should.contain('Expected sentence didn\'t match any step implemention')
+
+    def test_sentence_match_wrong_step(self):
+        """
+        Test if sentence matched wrong step
+        """
+        def foo():
+            "Test step func"
+            pass
+
+
+        steps = {
+            re.compile('foo'): foo
+        }
+        config = [{
+            'sentence': 'foo', 'should_match': 'bar'
+        }]
+
+        with patch('sys.stdout', new=StringIO()) as out:
+            matches.test_step_matches.when.called_with(config, steps).should.return_value((1, 0))
+            out.seek(0)
+            out.read().should.contain('Expected sentence matched foo instead of bar')
+
+    def test_sentence_argument_errors(self):
+        """
+        Test if sentence arguments do not match
+        """
+        def foo(step, foo, bar):
+            "Test step func"
+            pass
+
+
+        steps = {
+            re.compile(r'What (.*?) can (.*)'): foo
+        }
+        config = [{
+            'sentence': 'What FOO can BAR', 'should_match': 'foo',
+            'with-arguments': [
+                {'foo': 'foooooooo'},
+                {'bar': 'baaaaaaar'}
+            ]
+        }]
+
+        with patch('sys.stdout', new=StringIO()) as out:
+            matches.test_step_matches.when.called_with(config, steps).should.return_value((1, 0))
+            out.seek(0)
+            output = out.read()
+            output.should.contain('Expected argument "foo" with value "foooooooo" does not match value "FOO"')
+            output.should.contain('Expected argument "bar" with value "baaaaaaar" does not match value "BAR"')
+
+    def test_sentence_step_arguments_no_corresponding(self):
+        """
+        Test sentence step arguments without corresponding actual argument
+        """
+        expected_arguments = {
+            'foo': 'fooo'
+        }
+
+        actual_arguments = {
+            'FOO': None
+        }
+
+        matches.check_step_arguments.when.called_with(expected_arguments, actual_arguments).should.return_value([
+            'Expected argument "foo" is not in matched arguments [\'FOO\']'])
+
+    def test_sentence_step_arguments_type_mismatch(self):
+        """
+        Test sentence step arguments with type mismatch
+        """
+        expected_arguments = {
+            'foo': 'fooo'
+        }
+
+        actual_arguments = {
+            'foo': 42
+        }
+
+        matches.check_step_arguments.when.called_with(expected_arguments, actual_arguments).should.return_value([
+            'Expected argument "foo" is of type "int" instead "str"'])
+
+    def test_sentence_step_arguments_value_mismatch(self):
+        """
+        Test sentence step arguments with value mismatch
+        """
+        expected_arguments = {
+            'foo': 'fooo'
+        }
+
+        actual_arguments = {
+            'foo': 'foo'
+        }
+
+        matches.check_step_arguments.when.called_with(expected_arguments, actual_arguments).should.return_value([
+            'Expected argument "foo" with value "fooo" does not match value "foo"'])
+
+    def test_sentence_step_arguments_match(self):
+        """
+        Test sentence step arguments match
+        """
+        expected_arguments = {
+            'foo': 'foo',
+            'bar': 'bar'
+        }
+
+        actual_arguments = {
+            'foo': 'foo',
+            'bar': 'bar'
+        }
+
+        matches.check_step_arguments.when.called_with(expected_arguments, actual_arguments).should.return_value([])


### PR DESCRIPTION
This is *work in progress*.

## Goal
The goal is add a framework to test radish step implementations. This is especially useful if you want to deploy a test framework with radish steps. 

I see two levels of testing:
- The step interface -> Match sentences to step implementations (unit level)
- The step implementation -> Does the step implementation behave as expected?

## Status

- [x] Scripts to test step interface
- [x] Show missing sentences for step interface coverage
- [x] Document how to test the step interface
- [x] Add unit tests for step interface code
- [x] Add integration tests for step interface code (partially done)
- [ ] Framework to test step implementations
- [ ] Document how to test the step implementations
- [ ] Add unit tests for step implementation code
- [ ] Add integration tests for step implementation code
