### PR TITLE
fix exception handling not to use any try/except code for py2/py3

### DIFF
--- a/radish/compat.py
+++ b/radish/compat.py
@@ -4,18 +4,53 @@
     This module provide Oython 2 / Python 3 compatability
 """
 
-def unicode_(text):  # pragma: no cover
+from sys import version_info
+
+from .exceptions import PythonCompatibilityError
+
+
+# flags to indicate Python versions
+PY2 = None
+"""
+Flag to indication CPython 2 compatibility, set to True when running CPython 2
+False otherwise
+"""
+
+PY3 = None
+"""
+Flag to indication CPython 2 compatibility, set to True when running CPython 3
+False otherwise
+"""
+
+# check major version if 2 then set PY2 to True
+if version_info[0] == 2:  # pragma: no cover
+    PY2 = True
+# check major version if 3 then set PY3 to True
+elif version_info[0] == 3:  # pragma: no cover
+    PY3 = True
+else:   # pragma: no cover
+    PY2 = False
+    PY3 = False
+
+
+def u(text):  # pragma: no cover
     """
-    Encode given test to unicode utf-8 in manner that works accross python 2 and 3.
+    Encode given test to unicode utf-8 in manner that works accross various
+    python interpreters and version. Currently only support CPython 2 and 3.
 
     :param text: text to encode
     :type text: str,unicode
+
+    :raises PythonCompatibilityError:
+       if unicode support is not handled by interpreter/version
     """
     # look for unicode in the builtins which only exists in python 2
-    if hasattr(globals()['__builtins__'], 'unicode') is True:
+    if PY2 is True:
         unicode_text = unicode(text, "utf-8")
-    else:
+    elif PY3 is True:
         unicode_text = text
+    else:
+        msg = "unicode support unhandled for this Python interpreter/version"
+        raise PythonCompatibilityError(msg)
 
     return unicode_text
-

--- a/radish/compat.py
+++ b/radish/compat.py
@@ -35,7 +35,7 @@ else:   # pragma: no cover
 
 def u(text):  # pragma: no cover
     """
-    Encode given test to unicode utf-8 in manner that works accross various
+    Encode given text to unicode utf-8 in manner that works accross various
     python interpreters and version. Currently only support CPython 2 and 3.
 
     :param text: text to encode

--- a/radish/compat.py
+++ b/radish/compat.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+"""
+    This module provide Oython 2 / Python 3 compatability
+"""
+
+def unicode_(text):  # pragma: no cover
+    """
+    Encode given test to unicode utf-8 in manner that works accross python 2 and 3.
+
+    :param text: text to encode
+    :type text: str,unicode
+    """
+    # look for unicode in the builtins which only exists in python 2
+    if hasattr(globals()['__builtins__'], 'unicode') is True:
+        unicode_text = unicode(text, "utf-8")
+    else:
+        unicode_text = text
+
+    return unicode_text
+

--- a/radish/exceptions.py
+++ b/radish/exceptions.py
@@ -7,6 +7,12 @@ class RadishError(Exception):
     """
     pass
 
+class PythonCompatibilityError(RadishError):
+    """
+        Raised if python compatibility is not possible
+    """
+    def __init__(self, tag):
+        pass
 
 class LanguageNotSupportedError(RadishError):
     """

--- a/radish/utils.py
+++ b/radish/utils.py
@@ -24,10 +24,10 @@ class Failure(object):  # pylint: disable=too-few-public-methods
             :param Exception exception: the exception shrown in the step
         """
         self.exception = exception
-        try:
+        if hasattr(globals()['__builtins__'], 'unicode') is True:
             self.reason = unicode(str(exception), "utf-8")
             self.traceback = unicode(traceback.format_exc(), "utf-8")
-        except NameError:
+        else:
             self.reason = str(exception)
             self.traceback = traceback.format_exc()
 

--- a/radish/utils.py
+++ b/radish/utils.py
@@ -10,7 +10,7 @@ import sys
 import fnmatch
 import traceback
 
-from .compat import unicode_
+from .compat import u
 from .terrain import world
 
 
@@ -25,8 +25,8 @@ class Failure(object):  # pylint: disable=too-few-public-methods
             :param Exception exception: the exception shrown in the step
         """
         self.exception = exception
-        self.reason = unicode_(str(exception))
-        self.traceback = unicode_(traceback.format_exc())
+        self.reason = u(str(exception))
+        self.traceback = u(traceback.format_exc())
         self.name = exception.__class__.__name__
         traceback_info = traceback.extract_tb(sys.exc_info()[2])[-1]
         self.filename = traceback_info[0]

--- a/radish/utils.py
+++ b/radish/utils.py
@@ -10,6 +10,7 @@ import sys
 import fnmatch
 import traceback
 
+from .compat import unicode_
 from .terrain import world
 
 
@@ -24,13 +25,8 @@ class Failure(object):  # pylint: disable=too-few-public-methods
             :param Exception exception: the exception shrown in the step
         """
         self.exception = exception
-        if hasattr(globals()['__builtins__'], 'unicode') is True:
-            self.reason = unicode(str(exception), "utf-8")
-            self.traceback = unicode(traceback.format_exc(), "utf-8")
-        else:
-            self.reason = str(exception)
-            self.traceback = traceback.format_exc()
-
+        self.reason = unicode_(str(exception))
+        self.traceback = unicode_(traceback.format_exc())
         self.name = exception.__class__.__name__
         traceback_info = traceback.extract_tb(sys.exc_info()[2])[-1]
         self.filename = traceback_info[0]


### PR DESCRIPTION
fix exception handling not to use any try/except code for py2/py3
    compatability so the user does not get "confusing" messages like this:
    
      'During handling of the above exception, another exception occurred:'

along with additional tracebacks
```
Feature: Step Parameters (tutorial03)  # ./example.feature

    Scenario: Blenders
        Given I put "apples" in a blender
        When I switch the blender on
          Traceback (most recent call last):
            File "/tmp/bdd/_env36/lib/python3.6/site-packages/radish/stepmodel.py", line 91, in run
              self.definition_func(self, *self.arguments)  # pylint: disable=not-callable
            File "/tmp/bdd/radish/radish/example.py", line 34, in step_when_switch_blender_on
              raise Exception("hello")
          Exception: hello
          
          During handling of the above exception, another exception occurred:
          
          Traceback (most recent call last):
            File "/tmp/bdd/_env36/lib/python3.6/site-packages/radish/utils.py", line 28, in __init__
              self.reason = unicode(str(exception), "utf-8")
          Exception: hello
        Then it should transform into "apple juice"
```