### PR TITLE
Parse backgrounds that have no name

### DIFF
--- a/radish/parser.py
+++ b/radish/parser.py
@@ -214,7 +214,7 @@ class FeatureParser(object):
         :param str line: the line to parse the background
         """
         detected_background = self._detect_background(line)
-        if not detected_background:
+        if detected_background is None:
             # try to find a scenario
             if self._detect_scenario_type(line):
                 return self._parse_scenario(line)

--- a/tests/features/background-no-sentence.feature
+++ b/tests/features/background-no-sentence.feature
@@ -1,0 +1,14 @@
+Feature: Background with no sentence
+    Radish shall support Scenario Backgrounds that lack a sentence.
+
+    Background:
+        Given I have the number 5
+        And I have the number 3
+
+    Scenario: Add numbers
+        When I add them up
+        Then I expect the sum to be 8
+
+    Scenario: Subtract numbers
+        When I subtract them
+        Then I expect the difference to be 2

--- a/tests/functional/test_parser.py
+++ b/tests/functional/test_parser.py
@@ -479,6 +479,22 @@ def test_parse_simple_background(parser):
     assert len(feature.scenarios) == 2
     assert all(s.background.sentence == feature.background.sentence for s in feature.scenarios)
 
+@pytest.mark.parametrize('parser', [
+    ('background-no-sentence',)
+], indirect=['parser'])
+def test_parse_background_no_sentence(parser):
+    """
+    Test parsing a Feature with unnamed Background
+    """
+    # when
+    feature = parser.parse()
+
+    # then
+    assert isinstance(feature.background, Background)
+    assert feature.background.sentence == ''
+    assert len(feature.scenarios) == 2
+    assert all(s.background.sentence == feature.background.sentence for s in feature.scenarios)
+
 
 @pytest.mark.parametrize('parser', [
     ('background-scenariooutline',)


### PR DESCRIPTION
I'm used to writing feature backgrounds without a name/summary. However, when I do that, the background is included as part of the feature description:
```
$ radish show features
Feature: Simple Proxy  # features/simple_proxy.feature
    As an operator, I would like to monitor the number, frequency, and duration
    of connections without affecting their behavior at all.
    As a PostgreSQL user, I would like to connect without changing any of my
    settings.
    Background:
    Given postgres "pg0" is configured to trust connections
    And it is running
    Given pgtwixt is configured to connect to "pg0"
    And it is running

    Scenario: Clients connect and disconnect
```

The [`gherkin-official`](https://github.com/cucumber/gherkin-python) parser is happy with it:
```
$ gherkin --no-source --no-pickles features/simple_proxy.feature | jq .
...
        {
          "type": "Background",
          "location": { "column": 3, "line": 10 },
          "keyword": "Background",
          "name": "",
          "steps": [
            {
              "type": "Step",
              "location": { "column": 5, "line": 11 },
              "text": "postgres \"pg0\" is configured to trust connections",
              "keyword": "Given "
            },
            {
              "type": "Step",
              "location": { "column": 7, "line": 12 },
              "text": "it is running",
              "keyword": "And "
            },
            {
              "type": "Step",
              "location": { "column": 5, "line": 13 },
              "text": "pgtwixt is configured to connect to \"pg0\"",
              "keyword": "Given "
            },
            {
              "type": "Step",
              "location": { "column": 7, "line": 14 },
              "text": "it is running",
              "keyword": "And "
            }
          ]
        },
...
```

With this change, radish is too:
```
Feature: Simple Proxy  # features/simple_proxy.feature
    As an operator, I would like to monitor the number, frequency, and duration
    of connections without affecting their behavior at all.
    As a PostgreSQL user, I would like to connect without changing any of my
    settings.

    Background: 
        Given postgres "pg0" is configured to trust connections
        And it is running
        Given pgtwixt is configured to connect to "pg0"
        And it is running

    Scenario: Clients connect and disconnect
```