### PR TITLE
Fix features with preconditions and Tags

### DIFF
--- a/radish/parser.py
+++ b/radish/parser.py
@@ -251,7 +251,8 @@ class FeatureParser(object):
                         self._current_tags.append(Tag(tag[0], tag[1]))
                         if tag[0] == "precondition":
                             scenario = self._parse_precondition(tag[1])
-                            self._current_preconditions.append(scenario)
+                            if scenario is not None:
+                                self._current_preconditions.append(scenario)
                         elif tag[0] == "constant":
                             name, value = self._parse_constant(tag[1])
                             self._current_constants.append((name, value))
@@ -447,6 +448,9 @@ class FeatureParser(object):
                         "Your feature '{0}' has cycling preconditions with '{1}: {2}' starting at line {3}".format(
                             self._featurefile, feature_file_name, scenario_sentence, self._current_line))
                 raise
+
+        if feature is None:
+            return None
 
         if scenario_sentence not in feature:
             raise FeatureFileSyntaxError(

--- a/tests/exploratory/tags/features/SumNumbersPrecondition.feature
+++ b/tests/exploratory/tags/features/SumNumbersPrecondition.feature
@@ -1,0 +1,21 @@
+@Foo
+Feature: Test summing numbers
+  In order to test the basic
+  features of radish I test
+  to sum numbers.
+
+  @FooBar
+  Scenario: Sum two numbers
+    Given I have the number 5
+      And I have the number 3
+    When I sum them
+    Then I expect the result to be 8
+
+  @BarFoo
+  @precondition(SumNumbersPrecondition.feature: Sum two numbers)
+  Scenario: Sum three numbers
+    Given I have the number 5
+      And I have the number 3
+      And I have the number 2
+    When I sum them
+    Then I expect the result to be 18


### PR DESCRIPTION
This ensures that you can use a feature with
precondition and tags.

For example (working):

    - `radish features --tags 'Foo'`
    - `radish features --tags 'FooBar'`
    - `radish features --tags 'BarFoo or FooBar'`

It does not fix the precondition issue when you only
provide the `BarFoo` tag like this: `radish features --tags 'BarFoo'`

Signed-off-by: fliiiix <hi@l33t.name>