### PR TITLE
Use offical parse_type release again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ docopt==0.6.2
 ipython==5.3.0
 tag-expressions>=1.0.0
 lxml==4.2.6
-radish-parse_type==0.3.5
+parse_type==0.4.2
 coverage==4.5.2
 PyYAML==3.13
 humanize==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,7 @@ requirements = [
     "pysingleton",
     "colorful>=0.3.11",
     "tag-expressions>=1.0.0",
-    # FIXME(TF): this is a forked repository with
-    #            the parse version included we need.
-    #            change to upstream parse_type asap.
-    "radish-parse_type>0.3.4",
+    "parse_type>0.4.0",
     "humanize",
 ]
 


### PR DESCRIPTION
It looks to me that we can use the
offical parse_type again.

@timofurrer do you remember what the issue was?