### PR TITLE
Fix #221 flattened_basedirs on Windows by ; instead of :

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -40,7 +40,10 @@ containing steps and terrain functions from multiple locations:
 
 Since version v0.7.0 you can use multiple basedirs within one ``-b`` flag split
 by a colon (:). Similar to the possibilities you've got with ``$PATH``.
-This feature is not supported on Windows, because the colon (:) is used in almost any absolute path, e.g. ``C:\foo\bar``.
+On Windows it is not possbile to use a colon (:) because it is used
+in almost any absolute path, e.g. ``C:\foo\bar``.
+Since version v0.11.2 you can use a semicolon (;) on Windows for
+multiple basedirs.
 
 
 Run - Early exit

--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -40,6 +40,7 @@ containing steps and terrain functions from multiple locations:
 
 Since version v0.7.0 you can use multiple basedirs within one ``-b`` flag split
 by a colon (:). Similar to the possibilities you've got with ``$PATH``.
+This feature will *not* work on windows.
 
 
 Run - Early exit

--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -40,7 +40,7 @@ containing steps and terrain functions from multiple locations:
 
 Since version v0.7.0 you can use multiple basedirs within one ``-b`` flag split
 by a colon (:). Similar to the possibilities you've got with ``$PATH``.
-This feature will *not* work on windows.
+This feature is not supported on Windows, because the colon (:) is used in almost any absolute path, e.g. ``C:\foo\bar``.
 
 
 Run - Early exit

--- a/radish/utils.py
+++ b/radish/utils.py
@@ -190,4 +190,7 @@ def flattened_basedirs(basedirs):
     Multiple basedirs can be specified within a
     single element split by a colon.
     """
+    if os.name == "nt":
+        return basedirs
+
     return list(x for x in itertools.chain(*(x.split(":") for x in basedirs)) if x)

--- a/radish/utils.py
+++ b/radish/utils.py
@@ -190,7 +190,5 @@ def flattened_basedirs(basedirs):
     Multiple basedirs can be specified within a
     single element split by a colon.
     """
-    if os.name == "nt":
-        return basedirs
-
-    return list(x for x in itertools.chain(*(x.split(":") for x in basedirs)) if x)
+    separator = ";" if os.name == "nt" else ":"
+    return list(x for x in itertools.chain(*(x.split(separator) for x in basedirs)) if x)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -29,6 +29,7 @@ import radish.utils as utils
         ),
         (["foo:", ":bar"], ["foo", "bar"], "posix"),
         (["C:\\windows\\radish"], ["C:\\windows\\radish"], "nt"),
+        (["C:\\windows;radish"], ["C:\\windows", "radish"], "nt"),
     ],
 )
 def test_flattened_basedirs(mocker, basedirs, expected_basedirs, os_name):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -18,22 +18,25 @@ import radish.utils as utils
 
 
 @pytest.mark.parametrize(
-    "basedirs, expected_basedirs",
+    "basedirs, expected_basedirs, os_name",
     [
-        (["foo", "bar"], ["foo", "bar"]),
-        (["foo:bar", "foobar"], ["foo", "bar", "foobar"]),
+        (["foo", "bar"], ["foo", "bar"], "posix"),
+        (["foo:bar", "foobar"], ["foo", "bar", "foobar"], "posix"),
         (
             ["foo:bar", "foobar", "one:two:three"],
             ["foo", "bar", "foobar", "one", "two", "three"],
+            "posix"
         ),
-        (["foo:", ":bar"], ["foo", "bar"]),
+        (["foo:", ":bar"], ["foo", "bar"], "posix"),
+        (["C:\\windows\\radish"], ["C:\\windows\\radish"], "nt"),
     ],
 )
-def test_flattened_basedirs(basedirs, expected_basedirs):
+def test_flattened_basedirs(mocker, basedirs, expected_basedirs, os_name):
     """
     Test flatten basedirs
     """
     # given & when
+    mocker.patch("os.name", os_name)
     actual_basedirs = utils.flattened_basedirs(basedirs)
 
     # then


### PR DESCRIPTION
Splitting paths on Windows by : is not
a good idea. Since it looks like this
C:\\something. That is why we disable
this feature on Windows.

Signed-off-by: fliiiix <hi@l33t.name>