### PR TITLE
correct step text dedent - to be compliant with gherkin parser

### DIFF
--- a/tests/features/step-text-data.feature
+++ b/tests/features/step-text-data.feature
@@ -8,3 +8,21 @@ Feature: Step Text Data
             """
         When I look for it's author
         Then I will find Shakespeare
+
+    Scenario: YAML definition in Step with Text
+        When YAML specification is set to
+          """
+          version: '3'
+          services:
+            webapp:
+              build: ./dir
+          """
+        Then YAML specification contains proper data
+
+    Scenario: A step with text on endigs
+         When YAML specification is set to
+            """version: '3'
+            services:
+              webapp:
+                build: ./dir"""
+          Then YAML specification contains proper data

--- a/tests/output/unix/step-text-data.txt
+++ b/tests/output/unix/step-text-data.txt
@@ -2,20 +2,85 @@
     [37mRadish shall support Step Text Data[39m[26m
 
     [1m[37mScenario[22m[39m[26m: [1m[37mA Step with Text[22m[39m[26m
-        [1m[33mGiven I have the following quote[22m[39m[26m[1m[37m
+
+        [1m[33mGiven I have the following quote[22m[39m[26m[1m[37m
             """[22m[39m[36m
                 To be or not to be[39m[1m[37m
             """[22m[39m
-[A[K[A[K[A[K[A[K        [1m[32mGiven I have the following quote[22m[39m[26m[1m[37m
+
+[A[K
+[A[K
+[A[K
+[A[K        [1m[32mGiven I have the following quote[22m[39m[26m[1m[37m
             """[22m[39m[36m
                 To be or not to be[39m[1m[37m
             """[22m[39m
-        [1m[33mWhen I look for it's author[22m[39m[26m
-[A[K        [1m[32mWhen I look for it's author[22m[39m[26m
-        [1m[33mThen I will find Shakespeare[22m[39m[26m
-[A[K        [1m[32mThen I will find Shakespeare[22m[39m[26m
+
+        [1m[33mWhen I look for it's author[22m[39m[26m
+
+[A[K        [1m[32mWhen I look for it's author[22m[39m[26m
+
+        [1m[33mThen I will find Shakespeare[22m[39m[26m
+
+[A[K        [1m[32mThen I will find Shakespeare[22m[39m[26m
+
+    [1m[37mScenario[22m[39m[26m: [1m[37mYAML definition in Step with Text[22m[39m[26m
+
+        [1m[33mWhen YAML specification is set to[22m[39m[26m[1m[37m
+            """[22m[39m[36m
+                version: '3'
+                services:
+                  webapp:
+                    build: ./dir[39m[1m[37m
+            """[22m[39m
+
+[A[K
+[A[K
+[A[K
+[A[K
+[A[K
+[A[K
+[A[K        [1m[32mWhen YAML specification is set to[22m[39m[26m[1m[37m
+            """[22m[39m[36m
+                version: '3'
+                services:
+                  webapp:
+                    build: ./dir[39m[1m[37m
+            """[22m[39m
+
+        [1m[33mThen YAML specification contains proper data[22m[39m[26m
+
+[A[K        [1m[32mThen YAML specification contains proper data[22m[39m[26m
+
+    [1m[37mScenario[22m[39m[26m: [1m[37mA step with text on endigs[22m[39m[26m
+
+        [1m[33mWhen YAML specification is set to[22m[39m[26m[1m[37m
+            """[22m[39m[36m
+                version: '3'
+                services:
+                  webapp:
+                    build: ./dir[39m[1m[37m
+            """[22m[39m
+
+[A[K
+[A[K
+[A[K
+[A[K
+[A[K
+[A[K
+[A[K        [1m[32mWhen YAML specification is set to[22m[39m[26m[1m[37m
+            """[22m[39m[36m
+                version: '3'
+                services:
+                  webapp:
+                    build: ./dir[39m[1m[37m
+            """[22m[39m
+
+        [1m[33mThen YAML specification contains proper data[22m[39m[26m
+
+[A[K        [1m[32mThen YAML specification contains proper data[22m[39m[26m
 
 [1m[37m1 features ([22m[39m[1m[32m1 passed[22m[39m[1m[37m)[22m[39m
-[1m[37m1 scenarios ([22m[39m[1m[32m1 passed[22m[39m[1m[37m)[22m[39m
-[1m[37m3 steps ([22m[39m[1m[32m3 passed[22m[39m[1m[37m)[22m[39m
+[1m[37m3 scenarios ([22m[39m[1m[32m3 passed[22m[39m[1m[37m)[22m[39m
+[1m[37m7 steps ([22m[39m[1m[32m7 passed[22m[39m[1m[37m)[22m[39m
 [36mRun test-marker finished within a moment[39m

--- a/tests/output/windows/step-text-data.txt
+++ b/tests/output/windows/step-text-data.txt
@@ -24,7 +24,63 @@
 
 [A[K        [1m[32mThen I will find Shakespeare[22m[39m[26m
 
+    [1m[37mScenario[22m[39m[26m: [1m[37mYAML definition in Step with Text[22m[39m[26m
+
+        [1m[33mWhen YAML specification is set to[22m[39m[26m[1m[37m
+            """[22m[39m[36m
+                version: '3'
+                services:
+                  webapp:
+                    build: ./dir[39m[1m[37m
+            """[22m[39m
+
+[A[K
+[A[K
+[A[K
+[A[K
+[A[K
+[A[K
+[A[K        [1m[32mWhen YAML specification is set to[22m[39m[26m[1m[37m
+            """[22m[39m[36m
+                version: '3'
+                services:
+                  webapp:
+                    build: ./dir[39m[1m[37m
+            """[22m[39m
+
+        [1m[33mThen YAML specification contains proper data[22m[39m[26m
+
+[A[K        [1m[32mThen YAML specification contains proper data[22m[39m[26m
+
+    [1m[37mScenario[22m[39m[26m: [1m[37mA step with text on endigs[22m[39m[26m
+
+        [1m[33mWhen YAML specification is set to[22m[39m[26m[1m[37m
+            """[22m[39m[36m
+                version: '3'
+                services:
+                  webapp:
+                    build: ./dir[39m[1m[37m
+            """[22m[39m
+
+[A[K
+[A[K
+[A[K
+[A[K
+[A[K
+[A[K
+[A[K        [1m[32mWhen YAML specification is set to[22m[39m[26m[1m[37m
+            """[22m[39m[36m
+                version: '3'
+                services:
+                  webapp:
+                    build: ./dir[39m[1m[37m
+            """[22m[39m
+
+        [1m[33mThen YAML specification contains proper data[22m[39m[26m
+
+[A[K        [1m[32mThen YAML specification contains proper data[22m[39m[26m
+
 [1m[37m1 features ([22m[39m[1m[32m1 passed[22m[39m[1m[37m)[22m[39m
-[1m[37m1 scenarios ([22m[39m[1m[32m1 passed[22m[39m[1m[37m)[22m[39m
-[1m[37m3 steps ([22m[39m[1m[32m3 passed[22m[39m[1m[37m)[22m[39m
+[1m[37m3 scenarios ([22m[39m[1m[32m3 passed[22m[39m[1m[37m)[22m[39m
+[1m[37m7 steps ([22m[39m[1m[32m7 passed[22m[39m[1m[37m)[22m[39m
 [36mRun test-marker finished within a moment[39m

--- a/tests/radish/steps.py
+++ b/tests/radish/steps.py
@@ -182,3 +182,16 @@ def proper_cucumber_json_is_generated(step, expected_json_file):
             f_expected_cucumber_json, object_hook=remove_changing
         )
     assert cucumber_json == expected_cucumber_json
+
+
+@when("YAML specification is set to")
+def yaml_specification_is_set_to(step):
+    step.context.doc_text = step.text
+
+@then("YAML specification contains proper data")
+def yaml_specification_contains_correct_data(step):
+    expected_data = """version: '3'
+services:
+  webapp:
+    build: ./dir"""
+    assert step.context.doc_text == expected_data, '"{}" != "{}"'.format(step.context.doc_text, expected_data)


### PR DESCRIPTION
* Currently radish strips all white spaces before each line
    * it was not possible to provide yaml file via step text
      https://docs.cucumber.io/gherkin/reference/#doc-strings