### PR TITLE
fix: examples should support tags

### DIFF
--- a/radish/parser.py
+++ b/radish/parser.py
@@ -659,6 +659,10 @@ class FeatureParser(object):
         :returns: if a scenario of any type is present on the given line
         :rtype: bool
         """
+        if self._detect_examples(line_strip):
+            self._current_state = FeatureParser.State.EXAMPLES
+            return True
+
         if (
             self._detect_scenario(line)
             or self._detect_scenario_outline(line)

--- a/tests/features/tags-everywhere.feature
+++ b/tests/features/tags-everywhere.feature
@@ -17,6 +17,7 @@ Feature: Support Tags everywhere
         When I add them up
         Then I expect the sum to be <z>
 
+    @examples_tag
     Examples:
         | x | y | z |
         | 1 | 2 | 3 |


### PR DESCRIPTION
https://cucumber.io/docs/cucumber/api/#tags
Should be supported on Feature, Scenario, Scenario Outline and Examples.

FIX #416

I don't really understand the parser. 
@timofurrer if you can have a quick look if this is a good place to fix that?
Would be appreciated 