### PR TITLE
Fix --syslog-writer extention on Python3

### DIFF
--- a/radish/extensions/syslog_writer.py
+++ b/radish/extensions/syslog_writer.py
@@ -62,14 +62,7 @@ class SyslogWriter(object):
         :param string message: the message to log
         """
         import syslog
-
-        try:
-            if isinstance(message, unicode):
-                message = message.encode("utf8")
-        except Exception:  # pylint: disable=broad-except
-            pass
-        finally:
-            syslog.syslog(syslog.LOG_INFO, message)
+        syslog.syslog(syslog.LOG_INFO, message)
 
     def syslog_writer_before_all(
         self, features, marker

--- a/radish/extensions/syslog_writer.py
+++ b/radish/extensions/syslog_writer.py
@@ -4,6 +4,9 @@
 This module provides an extension to write all features, scenarios and steps to the syslog.
 """
 
+import os
+import sys
+
 from radish.terrain import world
 from radish.feature import Feature
 from radish.hookregistry import before, after
@@ -26,6 +29,10 @@ class SyslogWriter(object):
     LOAD_PRIORITY = 40
 
     def __init__(self):
+        if os.name == 'nt':
+            sys.stdout.write("Using --syslog on Windows is not supported.\n")
+            return
+
         # import syslog only if the extension got loaded
         # but not if the module got loaded.
         import syslog
@@ -41,7 +48,7 @@ class SyslogWriter(object):
 
     def get_scenario_feature(self, scenario):
         """
-            Gets the scenarios feature
+        Gets the scenarios feature
         """
         if not isinstance(scenario.parent, Feature):
             return scenario.parent.parent
@@ -72,7 +79,7 @@ class SyslogWriter(object):
         """
         import syslog
 
-        syslog.openlog(b"radish")
+        syslog.openlog("radish")
         self.log("begin run {0}".format(marker))
 
     def syslog_writer_after_all(

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
 """
-    radish
-    ~~~~~~
+radish
+~~~~~~
 
-    Behavior Driven Development tool for Python - the root from red to green
+Behavior Driven Development tool for Python - the root from red to green
 
-    Copyright: MIT, Timo Furrer <tuxtimo@gmail.com>
+Copyright: MIT, Timo Furrer <tuxtimo@gmail.com>
 """
 
 import os
@@ -214,6 +214,7 @@ from radish.main import main
             1,
             "everything_with_failures_dot_formatter",
         ),
+        (["feature-scenario-steps"], ["--syslog"], 0, "feature-scenario-steps-syslog"),
     ],
     ids=[
         "Empty Feature File",
@@ -293,6 +294,7 @@ from radish.main import main
         "Feature which fails with wip tag",
         "Feature which does not fail with wip tag",
         "Feature which has everything in it and some Scenario fail",
+        "Syslog extention is supported"
     ],
 )
 def test_main_cli_calls(

--- a/tests/output/unix/feature-scenario-steps-syslog.txt
+++ b/tests/output/unix/feature-scenario-steps-syslog.txt
@@ -1,0 +1,16 @@
+[1m[37mFeature[22m[39m[26m: [1m[37mFeature with a Scenario and Steps[22m[39m[26m  # [1m[30mfeatures/feature-scenario-steps.feature[22m[39m[26m
+    [37mRadish shall support parsing a Feature containing
+    a Scenario which contains multiple Steps[39m[26m
+
+    [1m[37mScenario[22m[39m[26m: [1m[37mScenario with multiple Steps[22m[39m[26m
+        [1m[33mGiven I have a Step[22m[39m[26m
+[A[K        [1m[32mGiven I have a Step[22m[39m[26m
+        [1m[33mWhen I do something[22m[39m[26m
+[A[K        [1m[32mWhen I do something[22m[39m[26m
+        [1m[33mThen I expect something[22m[39m[26m
+[A[K        [1m[32mThen I expect something[22m[39m[26m
+
+[1m[37m1 features ([22m[39m[1m[32m1 passed[22m[39m[1m[37m)[22m[39m
+[1m[37m1 scenarios ([22m[39m[1m[32m1 passed[22m[39m[1m[37m)[22m[39m
+[1m[37m3 steps ([22m[39m[1m[32m3 passed[22m[39m[1m[37m)[22m[39m
+[36mRun test-marker finished within a moment[39m

--- a/tests/output/windows/feature-scenario-steps-syslog.txt
+++ b/tests/output/windows/feature-scenario-steps-syslog.txt
@@ -1,0 +1,23 @@
+Using --syslog on Windows is not supported.
+[1m[37mFeature[22m[39m[26m: [1m[37mFeature with a Scenario and Steps[22m[39m[26m  # [1m[30mfeatures\feature-scenario-steps.feature[22m[39m[26m
+    [37mRadish shall support parsing a Feature containing
+    a Scenario which contains multiple Steps[39m[26m
+
+    [1m[37mScenario[22m[39m[26m: [1m[37mScenario with multiple Steps[22m[39m[26m
+
+        [1m[33mGiven I have a Step[22m[39m[26m
+
+[A[K        [1m[32mGiven I have a Step[22m[39m[26m
+
+        [1m[33mWhen I do something[22m[39m[26m
+
+[A[K        [1m[32mWhen I do something[22m[39m[26m
+
+        [1m[33mThen I expect something[22m[39m[26m
+
+[A[K        [1m[32mThen I expect something[22m[39m[26m
+
+[1m[37m1 features ([22m[39m[1m[32m1 passed[22m[39m[1m[37m)[22m[39m
+[1m[37m1 scenarios ([22m[39m[1m[32m1 passed[22m[39m[1m[37m)[22m[39m
+[1m[37m3 steps ([22m[39m[1m[32m3 passed[22m[39m[1m[37m)[22m[39m
+[36mRun test-marker finished within a moment[39m


### PR DESCRIPTION
Fixes #442 

- [x] fix behaviour or test for windows as we don't have `syslog` on windows