### PR TITLE
JUnit writter rollback

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -324,6 +324,14 @@ value must be a file path where the XML file should be written to.
 
   radish SomeFeature.feature --junit-xml /tmp/result.xml
 
+JUnit allows to add properties only to ``testsuite`` but tags on
+scenario level can be useful inside the matching ``testcase``.
+This can be achieved using ``--junit-relaxed``.
+
+.. code:: bash
+
+  radish SomeFeature.feature --junit-relaxed /tmp/result.xml
+
 Run - Log all features, scenarios, and steps to syslog
 ------------------------------------------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ def mock_world_config():
         "--help": False,
         "--inspect-after-failure": False,
         "--junit-xml": None,
+        "--junit-relaxed": False,
         "--marker": "time.time()",
         "--no-ansi": False,
         "--no-line-jump": False,

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -202,6 +202,12 @@ from radish.main import main
             "feature-scenario-steps",
         ),
         (
+            ["feature-scenario-steps"],
+            ["--junit-xml", tempfile.mkstemp()[1], "--junit-relaxed"],
+            0,
+            "feature-scenario-steps",
+        ),
+        (
             ["failing-scenario-middle"],
             ["--wip"],
             0,
@@ -291,6 +297,7 @@ from radish.main import main
         "Feature with single Scenario and Steps with embedded data producing Cucumber JSON",
         "Feature with scenario failure producing Cucumber JSON",
         "Feature with single Scenario and Steps producing JUnit XML",
+        "Feature with single Scenario and Steps producing relaxed JUnit XML",
         "Feature which fails with wip tag",
         "Feature which does not fail with wip tag",
         "Feature which has everything in it and some Scenario fail",

--- a/tests/unit/extensions/test_junit_xml_writer.py
+++ b/tests/unit/extensions/test_junit_xml_writer.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+
+"""
+radish
+~~~~~~
+
+Behavior Driven Development tool for Python - the root from red to green
+
+Copyright: MIT, Timo Furrer <tuxtimo@gmail.com>
+"""
+
+import pytest
+
+from datetime import datetime
+
+from radish.terrain import world
+from radish.exceptions import RadishError
+from radish.feature import Feature
+from radish.scenario import Scenario
+from radish.model import Tag
+from radish.extensions.junit_xml_writer import JUnitXMLWriter
+
+
+def test_empty_feature_list():
+    writer = JUnitXMLWriter()
+    no_features = []
+
+    with pytest.raises(RadishError):
+        writer.generate_junit_xml(no_features, "marker-is-ignored")
+
+
+def test_singel_feature_list(mocker):
+    stub = mocker.patch("radish.extensions.junit_xml_writer.JUnitXMLWriter._write_xml_to_disk")
+
+    first_feature = Feature(1, "Feature", "I am a feature", "foo.feature", 1, tags=None)
+    first_feature.starttime = datetime.utcnow()
+    first_feature.endtime = datetime.utcnow()
+
+    features = [first_feature]
+
+    writer = JUnitXMLWriter()
+    writer.generate_junit_xml(features, "marker-is-ignored")
+
+    assert "I am a feature" in str(stub.call_args[0])
+
+
+def test_normal_feature_list(mocker):
+    world.config.junit_relaxed = False
+    stub = mocker.patch("radish.extensions.junit_xml_writer.JUnitXMLWriter._write_xml_to_disk")
+
+    tags = [Tag("author", "batman")]
+
+    first_scenario = Scenario(
+        1,
+        "Scenario",
+        "I am a Scenario",
+        "foo.feature",
+        1,
+        parent=None,
+        tags=tags,
+        preconditions=None,
+        background=None,
+    )
+    first_scenario.starttime = datetime.utcnow()
+    first_scenario.endtime = datetime.utcnow()
+
+    first_feature = Feature(1, "Feature", "I am a feature", "foo.feature", 1, tags=None)
+    first_feature.starttime = datetime.utcnow()
+    first_feature.endtime = datetime.utcnow()
+    first_feature.scenarios.append(first_scenario)
+
+    features = [first_feature]
+
+    writer = JUnitXMLWriter()
+    writer.generate_junit_xml(features, "marker-is-ignored")
+
+    assert "I am a Scenario" in str(stub.call_args[0])
+    assert "properties" not in str(stub.call_args[0])
+
+
+def test_relaxed_mode_adding_tags_to_junit(mocker):
+    world.config.junit_relaxed = True
+    stub = mocker.patch("radish.extensions.junit_xml_writer.JUnitXMLWriter._write_xml_to_disk")
+
+    tags = [Tag("author", "batman")]
+
+    first_scenario = Scenario(
+        1,
+        "Scenario",
+        "I am a Scenario",
+        "foo.feature",
+        1,
+        parent=None,
+        tags=tags,
+        preconditions=None,
+        background=None,
+    )
+    first_scenario.starttime = datetime.utcnow()
+    first_scenario.endtime = datetime.utcnow()
+
+    first_feature = Feature(1, "Feature", "I am a feature", "foo.feature", 1, tags=None)
+    first_feature.starttime = datetime.utcnow()
+    first_feature.endtime = datetime.utcnow()
+    first_feature.scenarios.append(first_scenario)
+
+    features = [first_feature]
+
+    writer = JUnitXMLWriter()
+    writer.generate_junit_xml(features, "marker-is-ignored")
+
+    assert "author" in str(stub.call_args[0])
+    assert "batman" in str(stub.call_args[0])

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35,py36,py37,py38,py39,py310
+envlist = py35,py36,py37,py38,py39,py310,py311
 
 [testenv]
 commands =


### PR DESCRIPTION
Adding properties to testcases is not official JUnit standard.
It is hidden behind `--junit-relaxed` for now.