### PR TITLE
Adding the start time and end time of the step for cucumber json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - utcnow deprecation
 
 ### Changes
+- Adding start and end time in cucumber json
 - Drop Python 3.6 and Python 3.7
 - Drop the `--profile` option, please use `--user-data`
 - Change default marker from unix timestamp to UUIDv4

--- a/radish/extensions/cucumber_json_writer.py
+++ b/radish/extensions/cucumber_json_writer.py
@@ -89,7 +89,12 @@ class CucumberJSONWriter(object):
                         "keyword": step.sentence.split()[0],
                         "name": step.sentence,
                         "line": step.line,
-                        "result": {"status": step.state, "duration": duration},
+                        "result": {
+                            "status": step.state,
+                            "duration": duration,
+                            "starttime": str(step.starttime if step.starttime else 0.0),
+                            "endtime": str(step.endtime if step.endtime else 0.0),
+                        },
                     }
                     if step.state is Step.State.FAILED:
                         step_json["result"]["error_message"] = step.failure.reason

--- a/tests/output/cucumber-json.json
+++ b/tests/output/cucumber-json.json
@@ -15,6 +15,8 @@
                         "name": "Given I have the number 1",
                         "result": {
                             "duration": 343000.0,
+                            "endtime": "2024-11-20 08:37:18.133736+00:00",
+                            "starttime": "2024-11-20 08:37:17.255751+00:00",
                             "status": "passed"
                         }
                     },
@@ -24,6 +26,8 @@
                         "name": "And I have the number 2",
                         "result": {
                             "duration": 156000.0,
+                            "endtime": "2024-11-20 08:37:18.133736+00:00",
+                            "starttime": "2024-11-20 08:37:17.255751+00:00",
                             "status": "passed"
                         }
                     },
@@ -33,6 +37,8 @@
                         "name": "When I add them up with failure",
                         "result": {
                             "duration": 850000.0,
+                            "endtime": "2024-11-20 08:37:18.133736+00:00",
+                            "starttime": "2024-11-20 08:37:17.255751+00:00",
                             "error_message": "Unable to add numbers: [1, 2]",
                             "status": "failed"
                         }
@@ -43,6 +49,8 @@
                         "name": "Then I expect the sum to be 42",
                         "result": {
                             "duration": 73000.0,
+                            "endtime": "2024-11-20 08:37:18.133736+00:00",
+                            "starttime": "2024-11-20 08:37:17.255751+00:00",
                             "status": "skipped"
                         }
                     }
@@ -68,6 +76,8 @@
                         "name": "When generate cucumber report",
                         "result": {
                             "duration": 0.0,
+                            "endtime": "2024-11-20 08:37:18.133736+00:00",
+                            "starttime": "2024-11-20 08:37:17.255751+00:00",
                             "status": "skipped"
                         }
                     },
@@ -77,6 +87,8 @@
                         "name": "Then genreated cucumber json equals to \"cucumber-json.json\"",
                         "result": {
                             "duration": 0.0,
+                            "endtime": "2024-11-20 08:37:18.133736+00:00",
+                            "starttime": "2024-11-20 08:37:17.255751+00:00",
                             "status": "pending"
                         }
                     }

--- a/tests/radish/steps.py
+++ b/tests/radish/steps.py
@@ -162,7 +162,7 @@ def generate_cucumber_report(step):
 @then("genreated cucumber json equals to {expected_json_file:QuotedString}")
 def proper_cucumber_json_is_generated(step, expected_json_file):
     def remove_changing(d):
-        return {k: v for k, v in d.items() if k not in ["duration", "uri"]}
+        return {k: v for k, v in d.items() if k not in ["duration", "uri", "endtime", "starttime"]}
 
     with open(world.config.cucumber_json, "r") as f_cucumber_json:
         cucumber_json = json.load(f_cucumber_json, object_hook=remove_changing)


### PR DESCRIPTION
The current cucumber report is not really spec complient: https://github.com/cucumber/messages/blob/main/messages.md#teststepresult

replaces #474 