### PR TITLE
Fix for junit failure while using with --early-exit FIX #485

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 *Stay tuned...*
+### Fixed
+- Fix junit when using --early-exit
 
 ## [v0.18.1]
 

--- a/radish/extensions/junit_xml_writer.py
+++ b/radish/extensions/junit_xml_writer.py
@@ -127,12 +127,17 @@ class JUnitXMLWriter(object):
                 if not scenario.has_to_run(world.config.scenarios):
                     continue
 
-                testcase_element = etree.Element(
-                    "testcase",
-                    classname=feature.sentence,
-                    name=scenario.sentence,
-                    time="%.3f" % scenario.duration.total_seconds(),
-                )
+                if scenario.state not in [
+                    Step.State.UNTESTED,
+                    Step.State.PENDING,
+                    Step.State.SKIPPED,
+                ]:
+                    testcase_element = etree.Element(
+                        "testcase",
+                        classname=feature.sentence,
+                        name=scenario.sentence,
+                        time="%.3f" % scenario.duration.total_seconds(),
+                    )
 
                 if world.config.junit_relaxed:
                     properties_element = etree.Element("properties")


### PR DESCRIPTION
Fix #485 
In the case of early exit, the subsequent scenarios do not have starttime or endtime. Fixed it to skip those after early exit.