### PR TITLE
Skip loading duplicate step files

### DIFF
--- a/radish/loader.py
+++ b/radish/loader.py
@@ -6,10 +6,17 @@ import fnmatch
 import os
 
 
-def load_modules(location):
+def load_modules(location, loaded_files=None):
     """
     Loads all modules in the `location` folder
+
+    :param str location: the base directory to recursively load modules from
+    :param set[tuple[int, int]] loaded_files: device and inode nr of files already
+        loaded from another directory, used to avoid loading the same file twice.
     """
+    if loaded_files is None:
+        loaded_files = set()
+
     if os.name == "nt":
         location = location.replace("$PWD", os.getcwd())
 
@@ -19,7 +26,13 @@ def load_modules(location):
 
     for p, _, f in os.walk(location):
         for filename in fnmatch.filter(f, "*.py"):
-            load_module(os.path.join(p, filename))
+            path = os.path.join(p, filename)
+            stat = os.stat(path)
+            file_id = (stat.st_dev, stat.st_ino)
+            if file_id in loaded_files:
+                continue
+            loaded_files.add(file_id)
+            load_module(path)
 
 
 def load_module(path):

--- a/radish/main.py
+++ b/radish/main.py
@@ -55,8 +55,9 @@ def run_features(core):
     world.config.expand = True
 
     # load user's custom python files
+    loaded_files = set()
     for basedir in utils.flattened_basedirs(world.config.basedir):
-        load_modules(basedir)
+        load_modules(basedir, loaded_files=loaded_files)
 
     # match feature file steps with user's step definitions
     merge_steps(core.features, StepRegistry().steps)

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1,0 +1,86 @@
+"""
+radish
+~~~~~~
+
+Behavior Driven Development tool for Python - the root from red to green
+
+Copyright: MIT, Timo Furrer <tuxtimo@gmail.com>
+"""
+
+import pytest
+
+from radish import loader
+
+
+def test_load_modules_loads_all_files_in_dir(tmp_path, mocker):
+    """Load all Python files in a directory."""
+    dir_1 = tmp_path / "dir_1"
+    dir_1.mkdir()
+
+    dir_2 = tmp_path / "dir_2"
+    dir_2.mkdir()
+
+    module1 = dir_1 / "module1.py"
+    module2 = dir_2 / "module2.py"
+    module1.write_text("""
+    from radish import step
+    @step("Step 1")
+    def step_1():
+        pass""")
+    module2.write_text("""
+    from radish import step
+    @step("Step 2")
+    def step_2():
+        pass""")
+
+    load_module = mocker.patch("radish.loader.load_module")
+
+    loaded_files = set()
+    loader.load_modules(str(tmp_path / "dir_1"), loaded_files)
+    loader.load_modules(str(tmp_path / "dir_2"), loaded_files)
+
+    assert len(loaded_files) == 2
+    assert load_module.call_count == 2
+
+
+def test_load_modules_skips_identical_files(tmp_path, mocker):
+    """Do not load the same module twice through identical files."""
+    module = tmp_path / "module.py"
+    symlink = tmp_path / "module_alias.py"
+    module.write_text(
+        """
+    from radish import step
+    @step("My unique step")
+    def my_unique_step():
+        pass""",
+        encoding="utf-8",
+    )
+
+    try:
+        symlink.symlink_to(module, target_is_directory=False)
+    except (OSError, NotImplementedError) as error:
+        pytest.skip("creating symlinks is not supported: {}".format(error))
+
+    load_module = mocker.patch("radish.loader.load_module")
+
+    loader.load_modules(str(tmp_path))
+
+    load_module.assert_called_once()
+
+
+def test_load_modules_skips_loaded_files(tmp_path, mocker):
+    """Do not load the same module twice through already loaded files."""
+    module = tmp_path / "module.py"
+    module.write_text("""
+    from radish import step
+    @step("My unique step")
+    def my_unique_step():
+        pass""")
+
+    load_module = mocker.patch("radish.loader.load_module")
+
+    loaded_files = set()
+    loader.load_modules(str(tmp_path), loaded_files)
+    loader.load_modules(str(tmp_path), loaded_files)
+
+    load_module.assert_called_once()


### PR DESCRIPTION
If the basedir contains the same path twice or contains a subdir of a path, it tries to load it twice and fails.

Its more user friendly if it just avoids loadting the exact same file twice.